### PR TITLE
Add MySQL server installation

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -10,6 +10,19 @@ ENV PS_INSTALL_AUTO 1
 ENV PS_DEV_MODE 1
 ENV PS_ADMIN_FOLDER admin-dev
 ENV PS_INSTALL_FOLDER install-dev
+ENV DB_SERVER 127.0.0.1
+
+# MySQL installation
+# Avoid MySQL questions during installation
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo mysql-server-5.6 mysql-server/root_password password $DB_PASSWD | debconf-set-selections
+RUN echo mysql-server-5.6 mysql-server/root_password_again password $DB_PASSWD | debconf-set-selections
+RUN apt-get update \
+	&& apt-get install -y mysql-server \
+    && rm -rf /var/lib/apt/lists/*
+# MySQL configuration
+RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+EXPOSE 3306
 
 COPY config_files/docker-customization_run.sh /tmp/
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -12,6 +12,19 @@ ENV PS_DEV_MODE 1
 ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
+ENV DB_SERVER 127.0.0.1
+
+# MySQL installation
+# Avoid MySQL questions during installation
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo mysql-server-5.6 mysql-server/root_password password $DB_PASSWD | debconf-set-selections
+RUN echo mysql-server-5.6 mysql-server/root_password_again password $DB_PASSWD | debconf-set-selections
+RUN apt-get update \
+	&& apt-get install -y mysql-server \
+    && rm -rf /var/lib/apt/lists/*
+# MySQL configuration
+RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+EXPOSE 3306
 
 COPY config_files/my-minimal.cnf /etc/mysql/conf.d/my-minimal.cnf
 COPY config_files/docker-customization_run.sh /tmp/docker-customization_run.sh

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -12,6 +12,19 @@ ENV PS_DEV_MODE 1
 ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
+ENV DB_SERVER 127.0.0.1
+
+# MySQL installation
+# Avoid MySQL questions during installation
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo mysql-server-5.6 mysql-server/root_password password $DB_PASSWD | debconf-set-selections
+RUN echo mysql-server-5.6 mysql-server/root_password_again password $DB_PASSWD | debconf-set-selections
+RUN apt-get update \
+	&& apt-get install -y mysql-server \
+    && rm -rf /var/lib/apt/lists/*
+# MySQL configuration
+RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+EXPOSE 3306
 
 COPY config_files/my-minimal.cnf /etc/mysql/conf.d/my-minimal.cnf
 COPY config_files/docker-customization_run.sh /tmp/docker-customization_run.sh

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -12,6 +12,22 @@ ENV PS_DEV_MODE 1
 ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
+ENV DB_SERVER 127.0.0.1
+
+# MySQL installation
+# Avoid MySQL questions during installation
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo mysql-server-5.6 mysql-server/root_password password $DB_PASSWD | debconf-set-selections
+RUN echo mysql-server-5.6 mysql-server/root_password_again password $DB_PASSWD | debconf-set-selections
+RUN apt-get update \
+	&& apt-get install -y mysql-server \
+    && rm -rf /var/lib/apt/lists/*
+# MySQL configuration
+RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+EXPOSE 3306
+
+RUN service mysql start \
+	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 
 COPY config_files/my-minimal.cnf /etc/mysql/conf.d/my-minimal.cnf
 COPY config_files/docker-customization_run.sh /tmp/docker-customization_run.sh
@@ -20,7 +36,7 @@ RUN chmod u+x /tmp/docker-customization_run.sh /tmp/get-module.sh
 
 
 RUN sed -i -e"s/^exec\s*apache2-foreground/#exec apache2-foreground/" /tmp/docker_run.sh
-RUN /tmp/docker_run.sh
+RUN service mysql start && /tmp/docker_run.sh
 RUN sed -i -e"s/^#exec\s*apache2-foreground/exec apache2-foreground/" /tmp/docker_run.sh
 
 CMD ["/tmp/docker-customization_run.sh"]


### PR DESCRIPTION
We needs MySQL on machine shuffle, but I just removed it from the initial imag (https://github.com/PrestaShop/docker/pull/66). This PR moves the installation later.