### PR TITLE
Wait for MySQL startup 

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
 RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
 EXPOSE 3306
 
+RUN echo '[mysql.server]\nservice-startup-timeout = -1' >> /etc/mysql/conf.d/startup.cnf
 RUN service mysql start \
 	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
 RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
 EXPOSE 3306
 
+RUN echo '[mysql.server]\nservice-startup-timeout = -1' >> /etc/mysql/conf.d/startup.cnf
 RUN service mysql start \
 	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
 EXPOSE 3306
 
-RUN echo '[mysqld]\nservice-startup-timeout = 1' >> /etc/mysql/conf.d/startup.cnf
+RUN echo '[mysql.server]\nservice-startup-timeout = -1' >> /etc/mysql/conf.d/startup.cnf
 RUN service mysql start \
 	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
 RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
 EXPOSE 3306
 
+RUN echo '[mysqld]\nservice-startup-timeout = 1' >> /etc/mysql/conf.d/startup.cnf
 RUN service mysql start \
 	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 


### PR DESCRIPTION
This fixes a timeout happening during automatic deployment on Docker Hub

```
Step 19/27 : RUN service mysql start && mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
---> Running in 97b35361cd7b Starting MySQL database server: mysqld . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . failed!
Removing intermediate container 97b35361cd7b
```