### PR TITLE
Use localhost instead of IP for faster connections

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -10,7 +10,7 @@ ENV PS_INSTALL_AUTO 1
 ENV PS_DEV_MODE 1
 ENV PS_ADMIN_FOLDER admin-dev
 ENV PS_INSTALL_FOLDER install-dev
-ENV DB_SERVER 127.0.0.1
+ENV DB_SERVER localhost
 
 # MySQL installation
 # Avoid MySQL questions during installation

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -12,7 +12,7 @@ ENV PS_DEV_MODE 1
 ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
-ENV DB_SERVER 127.0.0.1
+ENV DB_SERVER localhost
 
 # MySQL installation
 # Avoid MySQL questions during installation

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -12,7 +12,7 @@ ENV PS_DEV_MODE 1
 ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
-ENV DB_SERVER 127.0.0.1
+ENV DB_SERVER localhost
 
 # MySQL installation
 # Avoid MySQL questions during installation

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -12,7 +12,7 @@ ENV PS_DEV_MODE 1
 ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
-ENV DB_SERVER 127.0.0.1
+ENV DB_SERVER localhost
 
 # MySQL installation
 # Avoid MySQL questions during installation


### PR DESCRIPTION
On machine shuffle, MySQL tries to reverse DNS the IP of its users. It seems there is some issues for him to get the information wanted, making the PHP requests over the Symfony framework slow ... really slow (~40 seconds).

We set `localhost` instead of `127.0.0.1` in order to use the socket available, because we run PHP and MySQL on the same server.