### PR TITLE
Stability and performance improvements

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -42,4 +42,6 @@ RUN sed -i -e"s/^exec\s*apache2-foreground/#exec apache2-foreground/" /tmp/docke
 RUN service mysql start && /tmp/docker_run.sh
 RUN sed -i -e"s/^#exec\s*apache2-foreground/exec apache2-foreground/" /tmp/docker_run.sh
 
+RUN rm -rf /var/www/html/modules/gamification
+
 CMD ["/tmp/docker-customization_run.sh"]

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -13,19 +13,23 @@ ENV PS_COUNTRY fr
 ENV PS_FOLDER_ADMIN admin-dev
 ENV PS_FOLDER_INSTALL install-dev
 ENV DB_SERVER localhost
+ENV DB_USER macfly
 
 # MySQL installation
 # Avoid MySQL questions during installation
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo mysql-server-5.6 mysql-server/root_password password $DB_PASSWD | debconf-set-selections
 RUN echo mysql-server-5.6 mysql-server/root_password_again password $DB_PASSWD | debconf-set-selections
-RUN curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=mariadb-10.1 \
-	&& apt install -y mariadb-server
+RUN apt update \
+  && apt install -y mysql-server \
+  && rm -rf /var/lib/apt/lists/*
 # MySQL configuration
-RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf
 EXPOSE 3306
 
+RUN echo '[mysql.server]\nservice-startup-timeout = -1' >> /etc/mysql/conf.d/startup.cnf
 RUN service mysql start \
+&& mysql -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWD'; GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'localhost'; FLUSH PRIVILEGES;" mysql \
 	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 
 COPY config_files/my-minimal.cnf /etc/mysql/conf.d/my-minimal.cnf

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -42,4 +42,6 @@ RUN sed -i -e"s/^exec\s*apache2-foreground/#exec apache2-foreground/" /tmp/docke
 RUN service mysql start && /tmp/docker_run.sh
 RUN sed -i -e"s/^#exec\s*apache2-foreground/exec apache2-foreground/" /tmp/docker_run.sh
 
+RUN rm -rf /var/www/html/modules/gamification
+
 CMD ["/tmp/docker-customization_run.sh"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:1.6
+FROM prestashop/prestashop:1.6-7.1-apache
 
 MAINTAINER Thomas Nabord <thomas.nabord@prestashop.com>
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:1.7
+FROM prestashop/prestashop:1.7-7.2-apache
 
 MAINTAINER Thomas Nabord <thomas.nabord@prestashop.com>
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -42,4 +42,6 @@ RUN sed -i -e"s/^exec\s*apache2-foreground/#exec apache2-foreground/" /tmp/docke
 RUN service mysql start && /tmp/docker_run.sh
 RUN sed -i -e"s/^#exec\s*apache2-foreground/exec apache2-foreground/" /tmp/docker_run.sh
 
+RUN rm -rf /var/www/html/modules/gamification
+
 CMD ["/tmp/docker-customization_run.sh"]


### PR DESCRIPTION
Improvements for Machine Shuffle:
* Remove gamification to avoid slow starts
* Use newer versions of PHP when possible
  * PrestaShop 1.6 now runs with PHP 7.1
  * PrestaShop 1.7 now runs with PHP 7.2
* Update 1.5 image with mysql latest changes