### PR TITLE
Use 1.7 instead of 1.7-7.2-apache

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:1.7-7.2-apache
+FROM prestashop/prestashop:1.7
 
 MAINTAINER Thomas Nabord <thomas.nabord@prestashop.com>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use 1.7 which is using the best PHP version for the best container version (fpm/apache) and the best prestashop version :) which mean 1.7.6.9 with 7.2 and apache at the moment we create this pull request.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
