### PR TITLE
Update service name from mysql to mariadb

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -40,7 +40,7 @@ RUN apt update \
 EXPOSE 443
 
 RUN echo '[mysql.server]\nservice-startup-timeout = -1' >> /etc/mysql/conf.d/startup.cnf
-RUN service mysql start \
+RUN service mariadb start \
 && mysql -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWD'; GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'localhost'; FLUSH PRIVILEGES;" mysql \
 	&& mysqladmin -h $DB_SERVER -P $DB_PORT -u $DB_USER -p$DB_PASSWD create $DB_NAME --force
 
@@ -54,11 +54,11 @@ RUN sed -ie "s/post_max_size\ =\ 20M/post_max_size\ =\ 40M/g" /usr/local/etc/php
 RUN sed -ie "s/upload_max_filesize\ =\ 20M/upload_max_filesize\ =\ 40M/g" /usr/local/etc/php/php.ini
 
 RUN sed -i -e"s/^exec\s*apache2-foreground/#exec apache2-foreground/" /tmp/docker_run.sh
-RUN service mysql start && /tmp/docker_run.sh
+RUN service mariadb start && /tmp/docker_run.sh
 RUN sed -i -e"s/^#exec\s*apache2-foreground/exec apache2-foreground/" /tmp/docker_run.sh
 
 COPY config_files/build/shop-build.php /tmp/build/shop-build.php
-RUN service mysql start \
+RUN service mariadb start \
   && runuser -g www-data -u www-data -- php /tmp/build/shop-build.php \
   && runuser -g www-data -u www-data -- php -d memory_limit=-1 bin/console cache:warmup --env=prod
 

--- a/1.7/config_files/docker-customization_run.sh
+++ b/1.7/config_files/docker-customization_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "\n* Starting MySQL server ...";
-service mysql start
+service mariadb start
 
 echo "\n* Updating PrestaShop domains ...";
 req='UPDATE ps_configuration SET value = "'$PS_DOMAIN'" WHERE name IN ("PS_SHOP_DOMAIN", "PS_SHOP_DOMAIN_SSL"); UPDATE ps_shop_url SET domain = "'$PS_DOMAIN'", domain_ssl = "'$PS_DOMAIN'";'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  Update service name from mysql to mariadb. It will allow builds to work again, so we can expect demo.prestashop.com and other services relying to this repo to see PrestaShop 1.7.8
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| How to test?      | `cd 1.7 && docker build -t prestashop/docker-internal-images:1.7 .` should pass
| Possible impacts? | If the requirements have changed, make sure the mysql version work  