### PR TITLE
Fix PS version for nightly docker image

### DIFF
--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -54,7 +54,7 @@ RUN sed -ie "s/post_max_size\ =\ 20M/post_max_size\ =\ 40M/g" /usr/local/etc/php
 RUN sed -ie "s/upload_max_filesize\ =\ 20M/upload_max_filesize\ =\ 40M/g" /usr/local/etc/php/php.ini
 
 RUN sed -i -e"s/^exec\s*apache2-foreground/#exec apache2-foreground/" /tmp/docker_run.sh
-RUN service mysql start && /tmp/docker_run.sh
+RUN service mysql start && /tmp/docker_nightly_run.sh
 RUN sed -i -e"s/^#exec\s*apache2-foreground/exec apache2-foreground/" /tmp/docker_run.sh
 
 COPY config_files/build/shop-build.php /tmp/build/shop-build.php

--- a/nightly/config_files/docker-customization_run.sh
+++ b/nightly/config_files/docker-customization_run.sh
@@ -20,4 +20,4 @@ fi
 unset GET_USER
 unset GET_FILE_MODULE
 
-bash /tmp/docker_run.sh
+bash /tmp/docker_nightly_run.sh


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Call the right script to build nightly image : `docker_nightly_run.sh` instead of `docker_run.sh`
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | Build a container based on the nightly image. Check that the version id correct : `cat install-dev/install_version.php` or `cat app/AppKernel.php`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
