### PR TITLE
Specify a xdebug version compatible with PHP 7.4

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -27,7 +27,7 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/*
 
 # XDebug extension
-RUN pecl install xdebug
+RUN pecl install xdebug-3.1.6
 
 # MySQL installation
 # Avoid MySQL questions during installation

--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -26,7 +26,7 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/*
 
 # XDebug extension
-RUN pecl install xdebug
+RUN pecl install xdebug-3.1.6
 
 # MySQL installation
 # Avoid MySQL questions during installation

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -26,7 +26,7 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/*
 
 # XDebug extension
-RUN pecl install xdebug
+RUN pecl install xdebug-3.1.6
 
 # MySQL installation
 # Avoid MySQL questions during installation


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes the build on 1.7, as the latest version of xdebug isn't compatible anymore with PHP below 8.0
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| How to test?      | `docker build -t prestashop/docker-internal-images:1.7 1.7` must pass
| Possible impacts? | /